### PR TITLE
Changes for allowing all tasks to be pickled

### DIFF
--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -4,17 +4,19 @@ Getting Started
 Installing and Upgrading
 ---------------------------
 
-Currently, the best way to install ``sciluigi`` and all of its dependencies is through the pre-built wheels stored
-on the shared drive.  The command is currently a bit long, but we're hoping to make this process easier in the future
-by abstracting all our packaging logic through a service such as Artifactory.
+If you have already installed the `pipelines repo <http://pipelines-docs.h3b.hope>`_, then SciLuigi will already be
+installed on your machine.  If you do not wish to install pipelines and want to install SciLuigi independenty, you can
+do so via our private `Artifactory <https://www.jfrog.com/artifactory/>`_ instance.  First, you'll need to
+`configure pip <http://pipelines-docs.h3b.hope/user_guide.html#installation>`_ to point to our Artifactory instance.
 
-For now, use the following command to install ``sciluigi``:
+You can then run the following command to install SciLuigi:
 
 .. code-block:: none
 
-    pip install --upgrade --no-index --find-links /h3/g/bi/projects/pipelines/wheels sciluigi
+    pip install h3sciluigi
 
-You can upgrade the code using the same command.
+**Note that you need to install** ``h3sciluigi`` **instead of** ``sciluigi``.  ``sciluigi`` **is the original package,**
+**while** ``h3sciluigi`` **contains our customizations.**
 
 Overview
 ---------

--- a/sciluigi/subworkflow.py
+++ b/sciluigi/subworkflow.py
@@ -19,12 +19,6 @@ class SubWorkflowTask(sciluigi.task.Task):
 
     def new_task(self, instance_name, cls, **kwargs):
         instance_name = '%s_%s' % (self.instance_name, instance_name)
-        if 'sciluigi_reduce_function' not in kwargs:
-            wf_dict = copy.deepcopy(self.workflow_task.__dict__)
-            if '_tasks' in wf_dict:
-                del wf_dict['_tasks']
-            kwargs['sciluigi_reduce_args'] = (self, instance_name, cls, copy.deepcopy(kwargs), wf_dict)
-            kwargs['sciluigi_reduce_function'] = sciluigi.task._new_task_unpickle
         return self.workflow_task.new_task(instance_name, cls, **kwargs)
 
     def connect_tasks(self):

--- a/sciluigi/subworkflow.py
+++ b/sciluigi/subworkflow.py
@@ -18,13 +18,13 @@ class SubWorkflowTask(sciluigi.task.Task):
 
     def new_task(self, instance_name, cls, **kwargs):
         instance_name = '%s_%s' % (self.instance_name, instance_name)
-        # if 'sciluigi_reduce_function' not in kwargs:
-        #     kwargs['sciluigi_reduce_args'] = (instance_name, cls, kwargs)
-        #     kwargs['sciluigi_reduce_function']  = self._new_task_unpickle
+        if 'sciluigi_reduce_function' not in kwargs:
+            kwargs['sciluigi_reduce_args'] = (instance_name, cls, kwargs)
+            kwargs['sciluigi_reduce_function']  = self._new_task_unpickle
         return self.workflow_task.new_task(instance_name, cls, **kwargs)
 
-    # def _new_task_unpickle(self, instance_name, cls, kwargs):
-    #     return self.new_task(instance_name, cls, **kwargs)
+    def _new_task_unpickle(self, instance_name, cls, kwargs):
+        return self.new_task(instance_name, cls, **kwargs)
 
     def connect_tasks(self):
         raise NotImplementedError

--- a/sciluigi/subworkflow.py
+++ b/sciluigi/subworkflow.py
@@ -18,7 +18,13 @@ class SubWorkflowTask(sciluigi.task.Task):
 
     def new_task(self, instance_name, cls, **kwargs):
         instance_name = '%s_%s' % (self.instance_name, instance_name)
+        if 'sciluigi_reduce_function' not in kwargs:
+            kwargs['sciluigi_reduce_args'] = (instance_name, cls, kwargs)
+            kwargs['sciluigi_reduce_function']  = self._new_task_unpickle
         return self.workflow_task.new_task(instance_name, cls, **kwargs)
+
+    def _new_task_unpickle(self, instance_name, cls, kwargs):
+        return self.new_task(instance_name, cls, **kwargs)
 
     def connect_tasks(self):
         raise NotImplementedError

--- a/sciluigi/subworkflow.py
+++ b/sciluigi/subworkflow.py
@@ -21,8 +21,8 @@ class SubWorkflowTask(sciluigi.task.Task):
         instance_name = '%s_%s' % (self.instance_name, instance_name)
         if 'sciluigi_reduce_function' not in kwargs:
             wf_dict = copy.deepcopy(self.workflow_task.__dict__)
-            if '_tasks' in wf_dict:
-                del wf_dict['_tasks']
+            # if '_tasks' in wf_dict:
+            #     del wf_dict['_tasks']
             kwargs['sciluigi_reduce_args'] = (self, instance_name, cls, copy.deepcopy(kwargs), wf_dict)
             kwargs['sciluigi_reduce_function'] = sciluigi.task._new_task_unpickle
         return self.workflow_task.new_task(instance_name, cls, **kwargs)

--- a/sciluigi/subworkflow.py
+++ b/sciluigi/subworkflow.py
@@ -9,11 +9,10 @@ class SubWorkflowTask(sciluigi.task.Task):
 
     def __init__(self, *args, **kwargs):
         super(sciluigi.task.Task, self).__init__(*args, **kwargs)
-        if not self.sciluigi_unpickling:
-            self.initialize_tasks()
-            self.initialize_inputs_and_outputs()
-            #self.endpoints = [self.connect_tasks()]
-            self.connect_tasks()
+        self.initialize_tasks()
+        self.initialize_inputs_and_outputs()
+        #self.endpoints = [self.connect_tasks()]
+        self.connect_tasks()
 
     def initialize_tasks(self):
         raise NotImplementedError

--- a/sciluigi/subworkflow.py
+++ b/sciluigi/subworkflow.py
@@ -21,8 +21,8 @@ class SubWorkflowTask(sciluigi.task.Task):
         instance_name = '%s_%s' % (self.instance_name, instance_name)
         if 'sciluigi_reduce_function' not in kwargs:
             wf_dict = copy.deepcopy(self.workflow_task.__dict__)
-            # if '_tasks' in wf_dict:
-            #     del wf_dict['_tasks']
+            if '_tasks' in wf_dict:
+                del wf_dict['_tasks']
             kwargs['sciluigi_reduce_args'] = (self, instance_name, cls, copy.deepcopy(kwargs), wf_dict)
             kwargs['sciluigi_reduce_function'] = sciluigi.task._new_task_unpickle
         return self.workflow_task.new_task(instance_name, cls, **kwargs)

--- a/sciluigi/subworkflow.py
+++ b/sciluigi/subworkflow.py
@@ -1,3 +1,4 @@
+import copy
 import logging
 import sciluigi
 
@@ -19,7 +20,7 @@ class SubWorkflowTask(sciluigi.task.Task):
     def new_task(self, instance_name, cls, **kwargs):
         instance_name = '%s_%s' % (self.instance_name, instance_name)
         if 'sciluigi_reduce_function' not in kwargs:
-            kwargs['sciluigi_reduce_args'] = (self, instance_name, cls, kwargs,
+            kwargs['sciluigi_reduce_args'] = (self, instance_name, cls, copy.deepcopy(kwargs),
                                               {k: v for k, v in self.__dict__.iteritems() if k != '_tasks'})
             kwargs['sciluigi_reduce_function'] = sciluigi.task._new_task_unpickle
         return self.workflow_task.new_task(instance_name, cls, **kwargs)

--- a/sciluigi/subworkflow.py
+++ b/sciluigi/subworkflow.py
@@ -19,7 +19,7 @@ class SubWorkflowTask(sciluigi.task.Task):
     def new_task(self, instance_name, cls, **kwargs):
         instance_name = '%s_%s' % (self.instance_name, instance_name)
         if 'sciluigi_reduce_function' not in kwargs:
-            kwargs['sciluigi_reduce_args'] = (self, instance_name, cls, kwargs, self.workflow_task.__dict__)
+            kwargs['sciluigi_reduce_args'] = (self, instance_name, cls, kwargs)
             kwargs['sciluigi_reduce_function'] = sciluigi.task._new_task_unpickle
         return self.workflow_task.new_task(instance_name, cls, **kwargs)
 

--- a/sciluigi/subworkflow.py
+++ b/sciluigi/subworkflow.py
@@ -9,15 +9,22 @@ class SubWorkflowTask(sciluigi.task.Task):
 
     def __init__(self, *args, **kwargs):
         super(sciluigi.task.Task, self).__init__(*args, **kwargs)
-        self.initialize_tasks()
-        self.initialize_inputs_and_outputs()
-        self.connect_tasks()
+        if not self.sciluigi_unpickling:
+            self.initialize_tasks()
+            self.initialize_inputs_and_outputs()
+            self.connect_tasks()
 
     def initialize_tasks(self):
         raise NotImplementedError
 
     def new_task(self, instance_name, cls, **kwargs):
         instance_name = '%s_%s' % (self.instance_name, instance_name)
+        if 'sciluigi_reduce_function' not in kwargs:
+            wf_dict = copy.deepcopy(self.workflow_task.__dict__)
+            if '_tasks' in wf_dict:
+                del wf_dict['_tasks']
+            kwargs['sciluigi_reduce_args'] = (self, instance_name, cls, copy.deepcopy(kwargs), wf_dict)
+            kwargs['sciluigi_reduce_function'] = sciluigi.task._new_task_unpickle
         return self.workflow_task.new_task(instance_name, cls, **kwargs)
 
     def connect_tasks(self):

--- a/sciluigi/subworkflow.py
+++ b/sciluigi/subworkflow.py
@@ -18,13 +18,13 @@ class SubWorkflowTask(sciluigi.task.Task):
 
     def new_task(self, instance_name, cls, **kwargs):
         instance_name = '%s_%s' % (self.instance_name, instance_name)
-        if 'sciluigi_reduce_function' not in kwargs:
-            kwargs['sciluigi_reduce_args'] = (instance_name, cls, kwargs)
-            kwargs['sciluigi_reduce_function']  = self._new_task_unpickle
+        # if 'sciluigi_reduce_function' not in kwargs:
+        #     kwargs['sciluigi_reduce_args'] = (instance_name, cls, kwargs)
+        #     kwargs['sciluigi_reduce_function']  = self._new_task_unpickle
         return self.workflow_task.new_task(instance_name, cls, **kwargs)
 
-    def _new_task_unpickle(self, instance_name, cls, kwargs):
-        return self.new_task(instance_name, cls, **kwargs)
+    # def _new_task_unpickle(self, instance_name, cls, kwargs):
+    #     return self.new_task(instance_name, cls, **kwargs)
 
     def connect_tasks(self):
         raise NotImplementedError

--- a/sciluigi/subworkflow.py
+++ b/sciluigi/subworkflow.py
@@ -19,7 +19,8 @@ class SubWorkflowTask(sciluigi.task.Task):
     def new_task(self, instance_name, cls, **kwargs):
         instance_name = '%s_%s' % (self.instance_name, instance_name)
         if 'sciluigi_reduce_function' not in kwargs:
-            kwargs['sciluigi_reduce_args'] = (self, instance_name, cls, kwargs)
+            kwargs['sciluigi_reduce_args'] = (self, instance_name, cls, kwargs,
+                                              {k: v for k, v in self.__dict__.iteritems() if k != '_tasks'})
             kwargs['sciluigi_reduce_function'] = sciluigi.task._new_task_unpickle
         return self.workflow_task.new_task(instance_name, cls, **kwargs)
 

--- a/sciluigi/subworkflow.py
+++ b/sciluigi/subworkflow.py
@@ -9,10 +9,11 @@ class SubWorkflowTask(sciluigi.task.Task):
 
     def __init__(self, *args, **kwargs):
         super(sciluigi.task.Task, self).__init__(*args, **kwargs)
-        self.initialize_tasks()
-        self.initialize_inputs_and_outputs()
-        #self.endpoints = [self.connect_tasks()]
-        self.connect_tasks()
+        if not self.sciluigi_unpickling:
+            self.initialize_tasks()
+            self.initialize_inputs_and_outputs()
+            #self.endpoints = [self.connect_tasks()]
+            self.connect_tasks()
 
     def initialize_tasks(self):
         raise NotImplementedError

--- a/sciluigi/subworkflow.py
+++ b/sciluigi/subworkflow.py
@@ -19,7 +19,8 @@ class SubWorkflowTask(sciluigi.task.Task):
     def new_task(self, instance_name, cls, **kwargs):
         instance_name = '%s_%s' % (self.instance_name, instance_name)
         if 'sciluigi_reduce_function' not in kwargs:
-            kwargs['sciluigi_reduce_args'] = (self, instance_name, cls, kwargs)
+            kwargs['sciluigi_reduce_args'] = (self, instance_name, cls, kwargs, self.workflow_task._sciluigi_args,
+                                              self.workflow_task._sciluigi_kwargs)
             kwargs['sciluigi_reduce_function'] = sciluigi.task._new_task_unpickle
         return self.workflow_task.new_task(instance_name, cls, **kwargs)
 

--- a/sciluigi/subworkflow.py
+++ b/sciluigi/subworkflow.py
@@ -20,8 +20,10 @@ class SubWorkflowTask(sciluigi.task.Task):
     def new_task(self, instance_name, cls, **kwargs):
         instance_name = '%s_%s' % (self.instance_name, instance_name)
         if 'sciluigi_reduce_function' not in kwargs:
-            kwargs['sciluigi_reduce_args'] = (self, instance_name, cls, copy.deepcopy(kwargs),
-                                              {k: v for k, v in self.__dict__.iteritems() if k != '_tasks'})
+            wf_dict = copy.deepcopy(self.workflow_task.__dict__)
+            if '_tasks' in wf_dict:
+                del wf_dict['_tasks']
+            kwargs['sciluigi_reduce_args'] = (self, instance_name, cls, copy.deepcopy(kwargs), wf_dict)
             kwargs['sciluigi_reduce_function'] = sciluigi.task._new_task_unpickle
         return self.workflow_task.new_task(instance_name, cls, **kwargs)
 

--- a/sciluigi/subworkflow.py
+++ b/sciluigi/subworkflow.py
@@ -7,7 +7,8 @@ log = logging.getLogger('sciluigi-interface')
 
 class SubWorkflowTask(sciluigi.task.Task):
 
-    def __configure__(self):
+    def __init__(self, *args, **kwargs):
+        super(sciluigi.task.Task, self).__init__(*args, **kwargs)
         self.initialize_tasks()
         self.initialize_inputs_and_outputs()
         self.connect_tasks()

--- a/sciluigi/subworkflow.py
+++ b/sciluigi/subworkflow.py
@@ -19,8 +19,7 @@ class SubWorkflowTask(sciluigi.task.Task):
     def new_task(self, instance_name, cls, **kwargs):
         instance_name = '%s_%s' % (self.instance_name, instance_name)
         if 'sciluigi_reduce_function' not in kwargs:
-            kwargs['sciluigi_reduce_args'] = (self, instance_name, cls, kwargs, self.workflow_task._sciluigi_args,
-                                              self.workflow_task._sciluigi_kwargs)
+            kwargs['sciluigi_reduce_args'] = (self, instance_name, cls, kwargs, self.workflow_task.__dict__)
             kwargs['sciluigi_reduce_function'] = sciluigi.task._new_task_unpickle
         return self.workflow_task.new_task(instance_name, cls, **kwargs)
 

--- a/sciluigi/subworkflow.py
+++ b/sciluigi/subworkflow.py
@@ -20,7 +20,7 @@ class SubWorkflowTask(sciluigi.task.Task):
         instance_name = '%s_%s' % (self.instance_name, instance_name)
         if 'sciluigi_reduce_function' not in kwargs:
             kwargs['sciluigi_reduce_args'] = (self, instance_name, cls, kwargs)
-            kwargs['sciluigi_reduce_function'] = sciluigi.Task._new_task_unpickle
+            kwargs['sciluigi_reduce_function'] = sciluigi.task._new_task_unpickle
         return self.workflow_task.new_task(instance_name, cls, **kwargs)
 
     def connect_tasks(self):

--- a/sciluigi/subworkflow.py
+++ b/sciluigi/subworkflow.py
@@ -18,7 +18,7 @@ class SubWorkflowTask(sciluigi.task.Task):
 
     def new_task(self, instance_name, cls, **kwargs):
         instance_name = '%s_%s' % (self.instance_name, instance_name)
-        return sciluigi.new_task(instance_name, cls, **kwargs)
+        return self.workflow_task.new_task(instance_name, cls, **kwargs)
 
     def connect_tasks(self):
         raise NotImplementedError

--- a/sciluigi/subworkflow.py
+++ b/sciluigi/subworkflow.py
@@ -7,11 +7,9 @@ log = logging.getLogger('sciluigi-interface')
 
 class SubWorkflowTask(sciluigi.task.Task):
 
-    def __init__(self, *args, **kwargs):
-        super(sciluigi.task.Task, self).__init__(*args, **kwargs)
+    def __configure__(self):
         self.initialize_tasks()
         self.initialize_inputs_and_outputs()
-        #self.endpoints = [self.connect_tasks()]
         self.connect_tasks()
 
     def initialize_tasks(self):

--- a/sciluigi/subworkflow.py
+++ b/sciluigi/subworkflow.py
@@ -19,12 +19,9 @@ class SubWorkflowTask(sciluigi.task.Task):
     def new_task(self, instance_name, cls, **kwargs):
         instance_name = '%s_%s' % (self.instance_name, instance_name)
         if 'sciluigi_reduce_function' not in kwargs:
-            kwargs['sciluigi_reduce_args'] = (instance_name, cls, kwargs)
-            kwargs['sciluigi_reduce_function']  = self._new_task_unpickle
+            kwargs['sciluigi_reduce_args'] = (self, instance_name, cls, kwargs)
+            kwargs['sciluigi_reduce_function'] = sciluigi.Task._new_task_unpickle
         return self.workflow_task.new_task(instance_name, cls, **kwargs)
-
-    def _new_task_unpickle(self, instance_name, cls, kwargs):
-        return self.new_task(instance_name, cls, **kwargs)
 
     def connect_tasks(self):
         raise NotImplementedError

--- a/sciluigi/subworkflow.py
+++ b/sciluigi/subworkflow.py
@@ -17,7 +17,7 @@ class SubWorkflowTask(sciluigi.task.Task):
 
     def new_task(self, instance_name, cls, **kwargs):
         instance_name = '%s_%s' % (self.instance_name, instance_name)
-        return self.workflow_task.new_task(instance_name, cls, **kwargs)
+        return sciluigi.new_task(instance_name, cls, **kwargs)
 
     def connect_tasks(self):
         raise NotImplementedError

--- a/sciluigi/task.py
+++ b/sciluigi/task.py
@@ -48,10 +48,12 @@ class MetaTask(luigi.task_register.Register):
         # Allows us to pass in properties that aren't Luigi params
         sciluigi_reduce_function = kwargs.pop('sciluigi_reduce_function', None)
         sciluigi_reduce_args = kwargs.pop('sciluigi_reduce_args', None)
+        sciluigi_state = kwargs.pop('sciluigi_state', {})
 
         new_instance = super(MetaTask, cls).__call__(*args, **kwargs)
         new_instance.sciluigi_reduce_args = sciluigi_reduce_args
         new_instance.sciluigi_reduce_function = sciluigi_reduce_function
+        new_instance.sciluigi_State = sciluigi_state
         return new_instance
 
 
@@ -70,7 +72,7 @@ class Task(sciluigi.audit.AuditTrailHelpers, sciluigi.dependencies.DependencyHel
         return self
 
     def __reduce__(self):
-        return self.sciluigi_reduce_function, self.sciluigi_reduce_args
+        return self.sciluigi_reduce_function, self.sciluigi_reduce_args, self.sciluigi_state
 
     def __init__(self, *args, **kwargs):
         super(Task, self).__init__(*args, **kwargs)

--- a/sciluigi/task.py
+++ b/sciluigi/task.py
@@ -50,6 +50,7 @@ class MetaTask(luigi.task_register.Register):
 
         new_instance = super(MetaTask, cls).__call__(*args, **kwargs)
         new_instance.workflow_task = workflow_task
+        new_instance.__configure__()
         return new_instance
 
 
@@ -62,8 +63,7 @@ class Task(sciluigi.audit.AuditTrailHelpers, sciluigi.dependencies.DependencyHel
 
     instance_name = luigi.Parameter(significant=False)
 
-    def __init__(self, *args, **kwargs):
-        super(Task, self).__init__(*args, **kwargs)
+    def __configure__(self):
         self.initialize_inputs_and_outputs()
 
     def initialize_inputs_and_outputs(self):

--- a/sciluigi/task.py
+++ b/sciluigi/task.py
@@ -15,14 +15,13 @@ log = logging.getLogger('sciluigi-interface')
 # ==============================================================================
 
 
-def new_task(name, cls, workflow_task, **kwargs):
+def new_task(name, cls, **kwargs):
     '''
     Instantiate a new task. Not supposed to be used by the end-user
     (use WorkflowTask.new_task() instead).
     '''
     slurminfo = None
     kwargs['instance_name'] = name
-    kwargs['workflow_task'] = workflow_task
     newtask = cls(**kwargs)
     if slurminfo is not None:
         newtask.slurminfo = slurminfo
@@ -46,15 +45,15 @@ def _new_task_unpickle(instance, instance_name, cls, kwargs, wf_dict):
 class MetaTask(luigi.task_register.Register):
     def __call__(cls, *args, **kwargs):
         # Allows us to pass in properties that aren't Luigi params
-        workflow_task = kwargs.pop('workflow_task', None)
-
+        # workflow_task = kwargs.pop('workflow_task', None)
+        #
         new_instance = super(MetaTask, cls).__call__(*args, **kwargs)
-        new_instance.workflow_task = workflow_task
+        # new_instance.workflow_task = workflow_task
         new_instance.__configure__()
         return new_instance
 
 
-class Task(sciluigi.audit.AuditTrailHelpers, sciluigi.dependencies.DependencyHelpers, luigi.Task):
+class Task(sciluigi.dependencies.DependencyHelpers, luigi.Task):
     '''
     SciLuigi Task, implementing SciLuigi specific functionality for dependency resolution
     and audit trail logging.
@@ -121,16 +120,12 @@ def touch_unfulfilled_optional(task):
                 task.ex_local('touch ' + output.path)
 
 # ==============================================================================
-
-class ExternalTask(
-        sciluigi.audit.AuditTrailHelpers,
-        sciluigi.dependencies.DependencyHelpers,
-        luigi.ExternalTask):
+l
+class ExternalTask(sciluigi.dependencies.DependencyHelpers, luigi.ExternalTask):
     '''
     SviLuigi specific implementation of luigi.ExternalTask, representing existing
     files.
     '''
-    workflow_task = luigi.Parameter()
     instance_name = luigi.Parameter()
 
     def __init__(self, *args, **kwargs):

--- a/sciluigi/task.py
+++ b/sciluigi/task.py
@@ -24,7 +24,6 @@ def new_task(name, cls, workflow_task, **kwargs):
     slurminfo = None
     kwargs['instance_name'] = name
     kwargs['workflow_task'] = workflow_task
-    print name + ' - ' + cls.__name__
     newtask = cls(**kwargs)
     if slurminfo is not None:
         newtask.slurminfo = slurminfo

--- a/sciluigi/task.py
+++ b/sciluigi/task.py
@@ -36,7 +36,7 @@ def _new_task_unpickle(instance, instance_name, cls, kwargs):
     if hasattr(instance, 'workflow_task'):
         instance.workflow_task.__init__(**instance.sciluigi_workflow_kwargs)
     else:
-        instance.__init__(**instance.sciluigi_workflow_kwargs)
+        instance.__init__()
     return instance.new_task(instance_name, cls, **kwargs)
 
 

--- a/sciluigi/task.py
+++ b/sciluigi/task.py
@@ -69,13 +69,12 @@ class Task(sciluigi.audit.AuditTrailHelpers, sciluigi.dependencies.DependencyHel
     def __deepcopy__(self, memo):
         return self
 
-    def __reduce__(self):
-        return self.sciluigi_reduce_function, self.sciluigi_reduce_args
+    # def __reduce__(self):
+    #     return self.sciluigi_reduce_function, self.sciluigi_reduce_args
 
     def __init__(self, *args, **kwargs):
         super(Task, self).__init__(*args, **kwargs)
-        if not self.sciluigi_unpickling:
-            self.initialize_inputs_and_outputs()
+        self.initialize_inputs_and_outputs()
 
     def initialize_inputs_and_outputs(self):
         raise NotImplementedError

--- a/sciluigi/task.py
+++ b/sciluigi/task.py
@@ -120,7 +120,7 @@ def touch_unfulfilled_optional(task):
                 task.ex_local('touch ' + output.path)
 
 # ==============================================================================
-l
+
 class ExternalTask(sciluigi.dependencies.DependencyHelpers, luigi.ExternalTask):
     '''
     SviLuigi specific implementation of luigi.ExternalTask, representing existing

--- a/sciluigi/task.py
+++ b/sciluigi/task.py
@@ -20,7 +20,6 @@ def new_task(name, cls, workflow_task, **kwargs):
     Instantiate a new task. Not supposed to be used by the end-user
     (use WorkflowTask.new_task() instead).
     '''
-    log.info('Constructing ' + cls.__name__ + ' named ' + name)
     slurminfo = None
     kwargs['instance_name'] = name
     kwargs['workflow_task'] = workflow_task
@@ -31,9 +30,11 @@ def new_task(name, cls, workflow_task, **kwargs):
 
 
 def _new_task_unpickle(instance, instance_name, cls, kwargs, wf_dict):
-    # Make sure the workflow has been instantiated before any other unpickling is done
+    # Make sure the workflow has been initialized before any other unpickling is done
     if isinstance(instance, sciluigi.WorkflowTask):
         instance.__dict__.update(wf_dict)
+    else:
+        instance.workflow_task.__dict__.update(wf_dict)
     return instance.new_task(instance_name, cls, **kwargs)
 
 

--- a/sciluigi/task.py
+++ b/sciluigi/task.py
@@ -2,6 +2,7 @@
 This module contains sciluigi's subclasses of luigi's Task class.
 '''
 
+import copy
 import luigi
 import logging
 import subprocess as sub
@@ -54,6 +55,9 @@ class Task(sciluigi.audit.AuditTrailHelpers, sciluigi.dependencies.DependencyHel
     instance_name = luigi.Parameter(significant=False)
     sciluigi_reduce_function = luigi.Parameter(significant=False)
     sciluigi_reduce_args = luigi.Parameter(significant=False)
+
+    def __deepcopy__(self, memo):
+        return copy._reconstruct(self, super(Task, self).__reduce__(), 1, memo)
 
     def __reduce__(self):
         return self.sciluigi_reduce_function, self.sciluigi_reduce_args

--- a/sciluigi/task.py
+++ b/sciluigi/task.py
@@ -64,7 +64,7 @@ class Task(sciluigi.audit.AuditTrailHelpers, sciluigi.dependencies.DependencyHel
 
     workflow_task = luigi.Parameter(significant=False)
     instance_name = luigi.Parameter(significant=False)
-    sciluigi_unpickling = luigi.Parameter(significant=False)
+    sciluigi_unpickling = luigi.Parameter(default=False, significant=False)
 
     def __deepcopy__(self, memo):
         return self

--- a/sciluigi/task.py
+++ b/sciluigi/task.py
@@ -29,16 +29,14 @@ def new_task(name, cls, workflow_task, **kwargs):
     return newtask
 
 
-def _new_task_unpickle(instance, instance_name, cls, kwargs, wf_dict):
+def _new_task_unpickle(instance, instance_name, cls, kwargs):
     # Make sure the workflow has been initialized before any other unpickling is done
     if isinstance(instance, sciluigi.WorkflowTask):
         if not hasattr(instance, '_tasks'):
             instance._tasks = {}
-        instance.__dict__.update(wf_dict)
     else:
         if not hasattr(instance.workflow_task, '_tasks'):
             instance.workflow_task._tasks = {}
-        instance.workflow_task.__dict__
     return instance.new_task(instance_name, cls, **kwargs)
 
 

--- a/sciluigi/task.py
+++ b/sciluigi/task.py
@@ -20,6 +20,7 @@ def new_task(name, cls, workflow_task, **kwargs):
     Instantiate a new task. Not supposed to be used by the end-user
     (use WorkflowTask.new_task() instead).
     '''
+    print 'Constructing {} with name {}'.format(cls.__name__, name)
     slurminfo = None
     kwargs['instance_name'] = name
     kwargs['workflow_task'] = workflow_task

--- a/sciluigi/task.py
+++ b/sciluigi/task.py
@@ -20,6 +20,7 @@ def new_task(name, cls, workflow_task, **kwargs):
     Instantiate a new task. Not supposed to be used by the end-user
     (use WorkflowTask.new_task() instead).
     '''
+    log.info('Constructing ' + cls.__name__ + ' named ' + name)
     slurminfo = None
     kwargs['instance_name'] = name
     kwargs['workflow_task'] = workflow_task

--- a/sciluigi/task.py
+++ b/sciluigi/task.py
@@ -36,11 +36,17 @@ class Task(sciluigi.audit.AuditTrailHelpers, sciluigi.dependencies.DependencyHel
     '''
     workflow_task = luigi.Parameter(significant=False)
     instance_name = luigi.Parameter(significant=False)
-    sciluigi_reduce_function = luigi.Parameter(significant=False)
-    sciluigi_reduce_args = luigi.Parameter(significant=False)
+    #sciluigi_reduce_function = luigi.Parameter(significant=False)
+    #sciluigi_reduce_args = luigi.Parameter(significant=False)
 
-    def __reduce__(self):
-        return self.sciluigi_reduce_function, self.sciluigi_reduce_args
+    #def __reduce__(self):
+    #    return self.sciluigi_reduce_function, self.sciluigi_reduce_args
+
+    def __getstate__(self):
+        return self.__dict__
+
+    def __setstate__(self, d):
+        self.__dict__.update(d)
 
     def __init__(self, *args, **kwargs):
         super(Task, self).__init__(*args, **kwargs)

--- a/sciluigi/task.py
+++ b/sciluigi/task.py
@@ -46,12 +46,10 @@ def _new_task_unpickle(instance, instance_name, cls, kwargs, wf_dict):
 class MetaTask(luigi.task_register.Register):
     def __call__(cls, *args, **kwargs):
         # Allows us to pass in properties that aren't Luigi params
-        sciluigi_reduce_function = kwargs.pop('sciluigi_reduce_function', None)
-        sciluigi_reduce_args = kwargs.pop('sciluigi_reduce_args', None)
+        workflow_task = kwargs.pop('workflow_task', None)
 
         new_instance = super(MetaTask, cls).__call__(*args, **kwargs)
-        new_instance.sciluigi_reduce_args = sciluigi_reduce_args
-        new_instance.sciluigi_reduce_function = sciluigi_reduce_function
+        new_instance.workflow_task = workflow_task
         return new_instance
 
 
@@ -64,25 +62,6 @@ class Task(sciluigi.audit.AuditTrailHelpers, sciluigi.dependencies.DependencyHel
 
     workflow_task = luigi.Parameter(significant=False)
     instance_name = luigi.Parameter(significant=False)
-    sciluigi_unpickling = luigi.Parameter(default=False, significant=False)
-
-    def __deepcopy__(self, memo):
-        return self
-
-    # def __reduce__(self):
-    #     return self.sciluigi_reduce_function, self.sciluigi_reduce_args
-
-    def printdict(self, inputdict):
-        for item in inputdict:
-            print item
-            if hasattr(inputdict[item], '__dict__'):
-                self.printdict(inputdict[item].__dict__)
-            else:
-                print inputdict[item]
-
-    def __setstate__(self, state):
-        print self.__class__
-        self.printdict(state)
 
     def __init__(self, *args, **kwargs):
         super(Task, self).__init__(*args, **kwargs)

--- a/sciluigi/task.py
+++ b/sciluigi/task.py
@@ -23,6 +23,9 @@ def new_task(name, cls, workflow_task, **kwargs):
     slurminfo = None
     kwargs['instance_name'] = name
     kwargs['workflow_task'] = workflow_task
+    print name + ' - ' + cls.__name__
+    if 'sciluigi_reduce_function' in kwargs:
+        print kwargs
     newtask = cls(**kwargs)
     if slurminfo is not None:
         newtask.slurminfo = slurminfo

--- a/sciluigi/task.py
+++ b/sciluigi/task.py
@@ -60,7 +60,6 @@ class Task(sciluigi.audit.AuditTrailHelpers, sciluigi.dependencies.DependencyHel
     '''
     __metaclass__ = MetaTask
 
-    workflow_task = luigi.Parameter(significant=False)
     instance_name = luigi.Parameter(significant=False)
 
     def __init__(self, *args, **kwargs):

--- a/sciluigi/task.py
+++ b/sciluigi/task.py
@@ -72,9 +72,17 @@ class Task(sciluigi.audit.AuditTrailHelpers, sciluigi.dependencies.DependencyHel
     # def __reduce__(self):
     #     return self.sciluigi_reduce_function, self.sciluigi_reduce_args
 
+    def printdict(self, inputdict):
+        for item in inputdict:
+            print item
+            if hasattr(inputdict[item], '__dict__'):
+                self.printdict(inputdict[item].__dict__)
+            else:
+                print inputdict[item]
+
     def __setstate__(self, state):
         print self.__class__
-        print state
+        self.printdict(state)
 
     def __init__(self, *args, **kwargs):
         super(Task, self).__init__(*args, **kwargs)

--- a/sciluigi/task.py
+++ b/sciluigi/task.py
@@ -36,6 +36,11 @@ class Task(sciluigi.audit.AuditTrailHelpers, sciluigi.dependencies.DependencyHel
     '''
     workflow_task = luigi.Parameter(significant=False)
     instance_name = luigi.Parameter(significant=False)
+    sciluigi_reduce_function = luigi.Parameter(significant=False)
+    sciluigi_reduce_args = luigi.Parameter(significant=False)
+
+    def __reduce__(self):
+        return self.sciluigi_reduce_function, self.sciluigi_reduce_args
 
     def __init__(self, *args, **kwargs):
         super(Task, self).__init__(*args, **kwargs)

--- a/sciluigi/task.py
+++ b/sciluigi/task.py
@@ -20,7 +20,6 @@ def new_task(name, cls, workflow_task, **kwargs):
     Instantiate a new task. Not supposed to be used by the end-user
     (use WorkflowTask.new_task() instead).
     '''
-    print 'Constructing {} with name {}'.format(cls.__name__, name)
     slurminfo = None
     kwargs['instance_name'] = name
     kwargs['workflow_task'] = workflow_task

--- a/sciluigi/task.py
+++ b/sciluigi/task.py
@@ -57,7 +57,7 @@ class Task(sciluigi.audit.AuditTrailHelpers, sciluigi.dependencies.DependencyHel
     sciluigi_reduce_args = luigi.Parameter(significant=False)
 
     def __deepcopy__(self, memo):
-        return copy._reconstruct(self, super(Task, self).__reduce__(), 1, memo)
+        return self
 
     def __reduce__(self):
         return self.sciluigi_reduce_function, self.sciluigi_reduce_args

--- a/sciluigi/task.py
+++ b/sciluigi/task.py
@@ -29,10 +29,10 @@ def new_task(name, cls, workflow_task, **kwargs):
     return newtask
 
 
-def _new_task_unpickle(instance, instance_name, cls, kwargs, wf_args, wf_kwargs):
+def _new_task_unpickle(instance, instance_name, cls, kwargs, wf_dict):
     # Make sure the workflow has been instantiated before any other unpickling is done
     if isinstance(instance, sciluigi.WorkflowTask):
-        instance.__init__(*wf_args, **wf_kwargs)
+        instance.__dict__.update(wf_dict)
     return instance.new_task(instance_name, cls, **kwargs)
 
 

--- a/sciluigi/task.py
+++ b/sciluigi/task.py
@@ -31,6 +31,8 @@ def new_task(name, cls, workflow_task, **kwargs):
 
 def _new_task_unpickle(instance, instance_name, cls, kwargs, wf_dict):
     # Make sure the workflow has been initialized before any other unpickling is done
+    log.info('Instance name = ' + instance_name)
+    log.info(wf_dict)
     if isinstance(instance, sciluigi.WorkflowTask):
         instance.__dict__.update(wf_dict)
         log.info(instance.__dict__)

--- a/sciluigi/task.py
+++ b/sciluigi/task.py
@@ -29,6 +29,10 @@ def new_task(name, cls, workflow_task, **kwargs):
     return newtask
 
 
+def _new_task_unpickle(instance, instance_name, cls, kwargs):
+    return instance.new_task(instance_name, cls, **kwargs)
+
+
 class Task(sciluigi.audit.AuditTrailHelpers, sciluigi.dependencies.DependencyHelpers, luigi.Task):
     '''
     SciLuigi Task, implementing SciLuigi specific functionality for dependency resolution
@@ -40,10 +44,7 @@ class Task(sciluigi.audit.AuditTrailHelpers, sciluigi.dependencies.DependencyHel
     sciluigi_reduce_args = luigi.Parameter(significant=False)
 
     def __reduce__(self):
-        return_val = self.sciluigi_reduce_function, self.sciluigi_reduce_args
-        self.sciluigi_reduce_function = None
-        self.sciluigi_reduce_args = None
-        return return_val
+        return self.sciluigi_reduce_function, self.sciluigi_reduce_args
 
     def __init__(self, *args, **kwargs):
         super(Task, self).__init__(*args, **kwargs)

--- a/sciluigi/task.py
+++ b/sciluigi/task.py
@@ -30,10 +30,10 @@ def new_task(name, cls, workflow_task, **kwargs):
     return newtask
 
 
-def _new_task_unpickle(instance, instance_name, cls, kwargs):
+def _new_task_unpickle(instance, instance_name, cls, kwargs, wf_args, wf_kwargs):
     # Make sure the workflow has been instantiated before any other unpickling is done
     if isinstance(instance, sciluigi.WorkflowTask):
-        instance.__init__(*instance._sciluigi_args, **instance._sciluigi_kwargs)
+        instance.__init__(*wf_args, **wf_kwargs)
     return instance.new_task(instance_name, cls, **kwargs)
 
 

--- a/sciluigi/task.py
+++ b/sciluigi/task.py
@@ -33,8 +33,10 @@ def _new_task_unpickle(instance, instance_name, cls, kwargs, wf_dict):
     # Make sure the workflow has been initialized before any other unpickling is done
     if isinstance(instance, sciluigi.WorkflowTask):
         instance.__dict__.update(wf_dict)
+        log.info(instance.__dict__)
     else:
         instance.workflow_task.__dict__.update(wf_dict)
+        log.info(instance.workflow_task.__dict__)
     return instance.new_task(instance_name, cls, **kwargs)
 
 

--- a/sciluigi/task.py
+++ b/sciluigi/task.py
@@ -50,7 +50,7 @@ class MetaTask(luigi.task_register.Register):
         return new_instance
 
 
-class Task(sciluigi.dependencies.DependencyHelpers, luigi.Task):
+class Task(sciluigi.audit.AuditTrailHelpers, sciluigi.dependencies.DependencyHelpers, luigi.Task):
     '''
     SciLuigi Task, implementing SciLuigi specific functionality for dependency resolution
     and audit trail logging.
@@ -63,7 +63,7 @@ class Task(sciluigi.dependencies.DependencyHelpers, luigi.Task):
 
     def __init__(self, *args, **kwargs):
         super(Task, self).__init__(*args, **kwargs)
-        self.initialize_inputs_and_outputs())
+        self.initialize_inputs_and_outputs()
 
 
     def initialize_inputs_and_outputs(self):
@@ -118,12 +118,13 @@ def touch_unfulfilled_optional(task):
 
 # ==============================================================================
 
-class ExternalTask(sciluigi.dependencies.DependencyHelpers, luigi.ExternalTask):
+class ExternalTask(sciluigi.audit.AuditTrailHelpers, sciluigi.dependencies.DependencyHelpers, luigi.ExternalTask):
     '''
     SviLuigi specific implementation of luigi.ExternalTask, representing existing
     files.
     '''
-    workflow_task = luigi.Parameter(    instance_name = luigi.Parameter()()
+    workflow_task = luigi.Parameter(significant=False)
+    instance_name = luigi.Parameter(significant=False)
 
     def __init__(self, *args, **kwargs):
         super(ExternalTask, self).__init__(*args, **kwargs)

--- a/sciluigi/task.py
+++ b/sciluigi/task.py
@@ -72,6 +72,10 @@ class Task(sciluigi.audit.AuditTrailHelpers, sciluigi.dependencies.DependencyHel
     # def __reduce__(self):
     #     return self.sciluigi_reduce_function, self.sciluigi_reduce_args
 
+    def __setstate__(self, state):
+        print self.__class__
+        print state
+
     def __init__(self, *args, **kwargs):
         super(Task, self).__init__(*args, **kwargs)
         self.initialize_inputs_and_outputs()

--- a/sciluigi/task.py
+++ b/sciluigi/task.py
@@ -48,12 +48,11 @@ class MetaTask(luigi.task_register.Register):
         # Allows us to pass in properties that aren't Luigi params
         sciluigi_reduce_function = kwargs.pop('sciluigi_reduce_function', None)
         sciluigi_reduce_args = kwargs.pop('sciluigi_reduce_args', None)
-        sciluigi_state = kwargs.pop('sciluigi_state', {})
 
         new_instance = super(MetaTask, cls).__call__(*args, **kwargs)
         new_instance.sciluigi_reduce_args = sciluigi_reduce_args
         new_instance.sciluigi_reduce_function = sciluigi_reduce_function
-        new_instance.sciluigi_State = sciluigi_state
+        new_instance.sciluigi_state = new_instance.__dict__
         return new_instance
 
 

--- a/sciluigi/task.py
+++ b/sciluigi/task.py
@@ -33,7 +33,7 @@ def new_task(name, cls, workflow_task, **kwargs):
 def _new_task_unpickle(instance, instance_name, cls, kwargs):
     # Make sure the workflow has been instantiated before any other unpickling is done
     if isinstance(instance, sciluigi.WorkflowTask):
-        instance.__init__()
+        instance.__init__(*instance._sciluigi_args, **instance._sciluigi_kwargs)
     return instance.new_task(instance_name, cls, **kwargs)
 
 

--- a/sciluigi/task.py
+++ b/sciluigi/task.py
@@ -56,8 +56,8 @@ class Task(sciluigi.audit.AuditTrailHelpers, sciluigi.dependencies.DependencyHel
     def __deepcopy__(self, memo):
         return self
 
-    def __reduce__(self):
-        return self.sciluigi_reduce_function, self.sciluigi_reduce_args
+    # def __reduce__(self):
+    #     return self.sciluigi_reduce_function, self.sciluigi_reduce_args
 
     def __init__(self, *args, **kwargs):
         super(Task, self).__init__(*args, **kwargs)

--- a/sciluigi/task.py
+++ b/sciluigi/task.py
@@ -40,7 +40,10 @@ class Task(sciluigi.audit.AuditTrailHelpers, sciluigi.dependencies.DependencyHel
     sciluigi_reduce_args = luigi.Parameter(significant=False)
 
     def __reduce__(self):
-        return self.sciluigi_reduce_function, self.sciluigi_reduce_args, {'workflow_task': self.workflow_task}
+        return_val = self.sciluigi_reduce_function, self.sciluigi_reduce_args
+        self.sciluigi_reduce_function = None
+        self.sciluigi_reduce_args = None
+        return return_val
 
     def __init__(self, *args, **kwargs):
         super(Task, self).__init__(*args, **kwargs)

--- a/sciluigi/task.py
+++ b/sciluigi/task.py
@@ -29,14 +29,16 @@ def new_task(name, cls, workflow_task, **kwargs):
     return newtask
 
 
-def _new_task_unpickle(instance, instance_name, cls, kwargs):
+def _new_task_unpickle(instance, instance_name, cls, kwargs, wf_dict):
     # Make sure the workflow has been initialized before any other unpickling is done
     if isinstance(instance, sciluigi.WorkflowTask):
         if not hasattr(instance, '_tasks'):
             instance._tasks = {}
+        instance.__dict__.update(wf_dict)
     else:
         if not hasattr(instance.workflow_task, '_tasks'):
             instance.workflow_task._tasks = {}
+        instance.workflow_task.__dict__.update(wf_dict)
     return instance.new_task(instance_name, cls, **kwargs)
 
 

--- a/sciluigi/task.py
+++ b/sciluigi/task.py
@@ -31,14 +31,14 @@ def new_task(name, cls, workflow_task, **kwargs):
 
 def _new_task_unpickle(instance, instance_name, cls, kwargs, wf_dict):
     # Make sure the workflow has been initialized before any other unpickling is done
-    log.info('Instance name = ' + instance_name)
-    log.info(wf_dict)
+    print 'Instance name = ' + instance_name
+    print wf_dict
     if isinstance(instance, sciluigi.WorkflowTask):
         instance.__dict__.update(wf_dict)
-        log.info(instance.__dict__)
+        print instance.__dict__
     else:
         instance.workflow_task.__dict__.update(wf_dict)
-        log.info(instance.workflow_task.__dict__)
+        instance.workflow_task.__dict__
     return instance.new_task(instance_name, cls, **kwargs)
 
 

--- a/sciluigi/task.py
+++ b/sciluigi/task.py
@@ -25,8 +25,6 @@ def new_task(name, cls, workflow_task, **kwargs):
     kwargs['instance_name'] = name
     kwargs['workflow_task'] = workflow_task
     print name + ' - ' + cls.__name__
-    if 'sciluigi_reduce_function' in kwargs:
-        print kwargs
     newtask = cls(**kwargs)
     if slurminfo is not None:
         newtask.slurminfo = slurminfo

--- a/sciluigi/task.py
+++ b/sciluigi/task.py
@@ -24,7 +24,6 @@ def new_task(name, cls, workflow_task, **kwargs):
     slurminfo = None
     kwargs['instance_name'] = name
     kwargs['workflow_task'] = workflow_task
-    kwargs['sciluigi_workflow_kwargs'] = workflow_task.param_kwargs
     newtask = cls(**kwargs)
     if slurminfo is not None:
         newtask.slurminfo = slurminfo
@@ -33,9 +32,7 @@ def new_task(name, cls, workflow_task, **kwargs):
 
 def _new_task_unpickle(instance, instance_name, cls, kwargs):
     # Make sure the workflow has been instantiated before any other unpickling is done
-    if hasattr(instance, 'workflow_task'):
-        instance.workflow_task.__init__(**instance.sciluigi_workflow_kwargs)
-    else:
+    if isinstance(instance, sciluigi.WorkflowTask):
         instance.__init__()
     return instance.new_task(instance_name, cls, **kwargs)
 

--- a/sciluigi/task.py
+++ b/sciluigi/task.py
@@ -46,7 +46,6 @@ class Task(sciluigi.audit.AuditTrailHelpers, sciluigi.dependencies.DependencyHel
     instance_name = luigi.Parameter(significant=False)
     sciluigi_reduce_function = luigi.Parameter(significant=False)
     sciluigi_reduce_args = luigi.Parameter(significant=False)
-    sciluigi_workflow_kwargs = luigi.Parameter(significant=False)
 
     def __reduce__(self):
         return self.sciluigi_reduce_function, self.sciluigi_reduce_args

--- a/sciluigi/task.py
+++ b/sciluigi/task.py
@@ -36,17 +36,11 @@ class Task(sciluigi.audit.AuditTrailHelpers, sciluigi.dependencies.DependencyHel
     '''
     workflow_task = luigi.Parameter(significant=False)
     instance_name = luigi.Parameter(significant=False)
-    #sciluigi_reduce_function = luigi.Parameter(significant=False)
-    #sciluigi_reduce_args = luigi.Parameter(significant=False)
+    sciluigi_reduce_function = luigi.Parameter(significant=False)
+    sciluigi_reduce_args = luigi.Parameter(significant=False)
 
-    #def __reduce__(self):
-    #    return self.sciluigi_reduce_function, self.sciluigi_reduce_args
-
-    def __getstate__(self):
-        return self.__dict__
-
-    def __setstate__(self, d):
-        self.__dict__.update(d)
+    def __reduce__(self):
+        return self.sciluigi_reduce_function, self.sciluigi_reduce_args, {'workflow_task': self.workflow_task}
 
     def __init__(self, *args, **kwargs):
         super(Task, self).__init__(*args, **kwargs)

--- a/sciluigi/task.py
+++ b/sciluigi/task.py
@@ -56,8 +56,8 @@ class Task(sciluigi.audit.AuditTrailHelpers, sciluigi.dependencies.DependencyHel
     def __deepcopy__(self, memo):
         return self
 
-    # def __reduce__(self):
-    #     return self.sciluigi_reduce_function, self.sciluigi_reduce_args
+    def __reduce__(self):
+        return self.sciluigi_reduce_function, self.sciluigi_reduce_args
 
     def __init__(self, *args, **kwargs):
         super(Task, self).__init__(*args, **kwargs)

--- a/sciluigi/task.py
+++ b/sciluigi/task.py
@@ -48,12 +48,10 @@ class MetaTask(luigi.task_register.Register):
         # Allows us to pass in properties that aren't Luigi params
         sciluigi_reduce_function = kwargs.pop('sciluigi_reduce_function', None)
         sciluigi_reduce_args = kwargs.pop('sciluigi_reduce_args', None)
-        sciluigi_unpickling = kwargs.pop('sciluigi_unpickling', False)
 
         new_instance = super(MetaTask, cls).__call__(*args, **kwargs)
         new_instance.sciluigi_reduce_args = sciluigi_reduce_args
         new_instance.sciluigi_reduce_function = sciluigi_reduce_function
-        new_instance.sciluigi_unpickling = sciluigi_unpickling
         return new_instance
 
 
@@ -66,6 +64,7 @@ class Task(sciluigi.audit.AuditTrailHelpers, sciluigi.dependencies.DependencyHel
 
     workflow_task = luigi.Parameter(significant=False)
     instance_name = luigi.Parameter(significant=False)
+    sciluigi_unpickling = luigi.Parameter(significant=False)
 
     def __deepcopy__(self, memo):
         return self

--- a/sciluigi/task.py
+++ b/sciluigi/task.py
@@ -66,6 +66,10 @@ class Task(sciluigi.audit.AuditTrailHelpers, sciluigi.dependencies.DependencyHel
     def __configure__(self):
         self.initialize_inputs_and_outputs()
 
+    def __setstate__(self, state):
+        print self.__class__
+        print state
+
     def initialize_inputs_and_outputs(self):
         raise NotImplementedError
 

--- a/sciluigi/task.py
+++ b/sciluigi/task.py
@@ -24,6 +24,7 @@ def new_task(name, cls, workflow_task, **kwargs):
     slurminfo = None
     kwargs['instance_name'] = name
     kwargs['workflow_task'] = workflow_task
+    kwargs['sciluigi_workflow_kwargs'] = workflow_task.param_kwargs
     newtask = cls(**kwargs)
     if slurminfo is not None:
         newtask.slurminfo = slurminfo
@@ -31,6 +32,11 @@ def new_task(name, cls, workflow_task, **kwargs):
 
 
 def _new_task_unpickle(instance, instance_name, cls, kwargs):
+    # Make sure the workflow has been instantiated before any other unpickling is done
+    if hasattr(instance, 'workflow_task'):
+        instance.workflow_task.__init__(**instance.sciluigi_workflow_kwargs)
+    else:
+        instance.__init__(**instance.sciluigi_workflow_kwargs)
     return instance.new_task(instance_name, cls, **kwargs)
 
 
@@ -43,6 +49,7 @@ class Task(sciluigi.audit.AuditTrailHelpers, sciluigi.dependencies.DependencyHel
     instance_name = luigi.Parameter(significant=False)
     sciluigi_reduce_function = luigi.Parameter(significant=False)
     sciluigi_reduce_args = luigi.Parameter(significant=False)
+    sciluigi_workflow_kwargs = luigi.Parameter(significant=False)
 
     def __reduce__(self):
         return self.sciluigi_reduce_function, self.sciluigi_reduce_args

--- a/sciluigi/task.py
+++ b/sciluigi/task.py
@@ -31,13 +31,13 @@ def new_task(name, cls, workflow_task, **kwargs):
 
 def _new_task_unpickle(instance, instance_name, cls, kwargs, wf_dict):
     # Make sure the workflow has been initialized before any other unpickling is done
-    print 'Instance name = ' + instance_name
-    print wf_dict
     if isinstance(instance, sciluigi.WorkflowTask):
+        if not hasattr(instance, '_tasks'):
+            instance._tasks = {}
         instance.__dict__.update(wf_dict)
-        print instance.__dict__
     else:
-        instance.workflow_task.__dict__.update(wf_dict)
+        if not hasattr(instance.workflow_task, '_tasks'):
+            instance.workflow_task._tasks = {}
         instance.workflow_task.__dict__
     return instance.new_task(instance_name, cls, **kwargs)
 

--- a/sciluigi/workflow.py
+++ b/sciluigi/workflow.py
@@ -124,8 +124,10 @@ class WorkflowTask(sciluigi.audit.AuditTrailHelpers, luigi.Task):
         Create new task instance, and link it to the current workflow.
         '''
         if 'sciluigi_reduce_function' not in kwargs:
-            kwargs['sciluigi_reduce_args'] = (self, instance_name, cls, copy.deepcopy(kwargs),
-                                              {k: v for k, v in self.__dict__.iteritems() if k != '_tasks'})
+            wf_dict = copy.deepcopy(self.__dict__)
+            if '_tasks' in wf_dict:
+                del wf_dict['_tasks']
+            kwargs['sciluigi_reduce_args'] = (self, instance_name, cls, copy.deepcopy(kwargs), wf_dict)
             kwargs['sciluigi_reduce_function'] = sciluigi.task._new_task_unpickle
         newtask = sciluigi.new_task(instance_name, cls, self, **kwargs)
         self._tasks[instance_name] = newtask

--- a/sciluigi/workflow.py
+++ b/sciluigi/workflow.py
@@ -2,6 +2,7 @@
 This module contains sciluigi's subclasses of luigi's Task class.
 '''
 
+import copy
 import datetime
 import luigi
 import logging
@@ -123,7 +124,7 @@ class WorkflowTask(sciluigi.audit.AuditTrailHelpers, luigi.Task):
         Create new task instance, and link it to the current workflow.
         '''
         if 'sciluigi_reduce_function' not in kwargs:
-            kwargs['sciluigi_reduce_args'] = (self, instance_name, cls, kwargs,
+            kwargs['sciluigi_reduce_args'] = (self, instance_name, cls, copy.deepcopy(kwargs),
                                               {k: v for k, v in self.__dict__.iteritems() if k != '_tasks'})
             kwargs['sciluigi_reduce_function'] = sciluigi.task._new_task_unpickle
         newtask = sciluigi.new_task(instance_name, cls, self, **kwargs)

--- a/sciluigi/workflow.py
+++ b/sciluigi/workflow.py
@@ -14,6 +14,7 @@ import sciluigi.slurm
 
 log = logging.getLogger('sciluigi-interface')
 
+
 # ==============================================================================
 
 class WorkflowTask(sciluigi.audit.AuditTrailHelpers, luigi.Task):
@@ -24,11 +25,13 @@ class WorkflowTask(sciluigi.audit.AuditTrailHelpers, luigi.Task):
 
     instance_name = luigi.Parameter(default='sciluigi_workflow')
 
-    _tasks = {}
-    _wfstart = ''
-    _wflogpath = ''
-    _hasloggedstart = False
-    _hasloggedfinish = False
+    def __init__(self, *args, **kwargs):
+        super(WorkflowTask, self).__init__(*args, **kwargs)
+        self._tasks = {}
+        self._wfstart = ''
+        self._wflogpath = ''
+        self._hasloggedstart = False
+        self._hasloggedfinish = False
 
     def _ensure_timestamp(self):
         '''

--- a/sciluigi/workflow.py
+++ b/sciluigi/workflow.py
@@ -12,7 +12,6 @@ import sciluigi.audit
 import sciluigi.interface
 import sciluigi.dependencies
 import sciluigi.slurm
-import traceback
 
 log = logging.getLogger('sciluigi-interface')
 
@@ -87,7 +86,6 @@ class WorkflowTask(sciluigi.audit.AuditTrailHelpers, luigi.Task):
             log.info('SciLuigi: %s Workflow Started', clsname)
             log.info('-'*80)
             self._hasloggedstart = True
-        traceback.print_stack()
         workflow_output = self.workflow()
         if workflow_output is None:
             clsname = self.__class__.__name__

--- a/sciluigi/workflow.py
+++ b/sciluigi/workflow.py
@@ -2,13 +2,11 @@
 This module contains sciluigi's subclasses of luigi's Task class.
 '''
 
-import copy
 import datetime
 import luigi
 import logging
 import os
 import sciluigi
-import sciluigi.audit
 import sciluigi.interface
 import sciluigi.dependencies
 import sciluigi.slurm
@@ -18,7 +16,7 @@ log = logging.getLogger('sciluigi-interface')
 
 # ==============================================================================
 
-class WorkflowTask(sciluigi.audit.AuditTrailHelpers, luigi.Task):
+class WorkflowTask(luigi.Task):
     '''
     SciLuigi-specific task, that has a method for implementing a (dynamic) workflow
     definition (workflow()).
@@ -43,15 +41,6 @@ class WorkflowTask(sciluigi.audit.AuditTrailHelpers, luigi.Task):
         '''
         if self._wfstart == '':
             self._wfstart = datetime.datetime.utcnow().strftime('%Y%m%d_%H%M%S_%f')
-
-    def get_auditdirpath(self):
-        '''
-        Get the path to the workflow-speicfic audit trail directory.
-        '''
-        self._ensure_timestamp()
-        clsname = self.__class__.__name__.lower()
-        audit_dirpath = 'sciluigi-audit/audit_%s_%s' % (clsname, self._wfstart)
-        return audit_dirpath
 
     def get_auditlogpath(self):
         '''

--- a/sciluigi/workflow.py
+++ b/sciluigi/workflow.py
@@ -32,6 +32,8 @@ class WorkflowTask(sciluigi.audit.AuditTrailHelpers, luigi.Task):
         self._wflogpath = ''
         self._hasloggedstart = False
         self._hasloggedfinish = False
+        self._sciluigi_args = args
+        self._sciluigi_kwargs = kwargs
 
     def _ensure_timestamp(self):
         '''

--- a/sciluigi/workflow.py
+++ b/sciluigi/workflow.py
@@ -126,12 +126,6 @@ class WorkflowTask(sciluigi.audit.AuditTrailHelpers, luigi.Task):
         '''
         Create new task instance, and link it to the current workflow.
         '''
-        if 'sciluigi_reduce_function' not in kwargs:
-            wf_dict = copy.deepcopy(self.__dict__)
-            if '_tasks' in wf_dict:
-                del wf_dict['_tasks']
-            kwargs['sciluigi_reduce_args'] = (self, instance_name, cls, copy.deepcopy(kwargs), wf_dict)
-            kwargs['sciluigi_reduce_function'] = sciluigi.task._new_task_unpickle
         newtask = sciluigi.new_task(instance_name, cls, self, **kwargs)
         self._tasks[instance_name] = newtask
         return newtask

--- a/sciluigi/workflow.py
+++ b/sciluigi/workflow.py
@@ -34,6 +34,9 @@ class WorkflowTask(sciluigi.audit.AuditTrailHelpers, luigi.Task):
         self._hasloggedstart = False
         self._hasloggedfinish = False
 
+    def __deepcopy__(self, memo):
+        return self
+
     def _ensure_timestamp(self):
         '''
         Make sure that there is a time stamp for when the workflow started.

--- a/sciluigi/workflow.py
+++ b/sciluigi/workflow.py
@@ -33,12 +33,6 @@ class WorkflowTask(sciluigi.audit.AuditTrailHelpers, luigi.Task):
         self._hasloggedstart = False
         self._hasloggedfinish = False
 
-    def __repr__(self):
-        try:
-            return super(WorkflowTask, self).__repr__()
-        except AttributeError:
-            return self.__class__.__name__
-
     def _ensure_timestamp(self):
         '''
         Make sure that there is a time stamp for when the workflow started.
@@ -129,7 +123,8 @@ class WorkflowTask(sciluigi.audit.AuditTrailHelpers, luigi.Task):
         Create new task instance, and link it to the current workflow.
         '''
         if 'sciluigi_reduce_function' not in kwargs:
-            kwargs['sciluigi_reduce_args'] = (self, instance_name, cls, kwargs)
+            kwargs['sciluigi_reduce_args'] = (self, instance_name, cls, kwargs,
+                                              {k: v for k, v in self.__dict__.iteritems() if k != '_tasks'})
             kwargs['sciluigi_reduce_function'] = sciluigi.task._new_task_unpickle
         newtask = sciluigi.new_task(instance_name, cls, self, **kwargs)
         self._tasks[instance_name] = newtask

--- a/sciluigi/workflow.py
+++ b/sciluigi/workflow.py
@@ -33,6 +33,12 @@ class WorkflowTask(sciluigi.audit.AuditTrailHelpers, luigi.Task):
         self._hasloggedstart = False
         self._hasloggedfinish = False
 
+    def __repr__(self):
+        try:
+            super(WorkflowTask, self).__repr__()
+        except AttributeError:
+            return self.__class__.__name__
+
     def _ensure_timestamp(self):
         '''
         Make sure that there is a time stamp for when the workflow started.

--- a/sciluigi/workflow.py
+++ b/sciluigi/workflow.py
@@ -128,8 +128,8 @@ class WorkflowTask(sciluigi.audit.AuditTrailHelpers, luigi.Task):
         '''
         if 'sciluigi_reduce_function' not in kwargs:
             wf_dict = copy.deepcopy(self.__dict__)
-            # if '_tasks' in wf_dict:
-            #     del wf_dict['_tasks']
+            if '_tasks' in wf_dict:
+                del wf_dict['_tasks']
             kwargs['sciluigi_reduce_args'] = (self, instance_name, cls, copy.deepcopy(kwargs), wf_dict)
             kwargs['sciluigi_reduce_function'] = sciluigi.task._new_task_unpickle
         newtask = sciluigi.new_task(instance_name, cls, self, **kwargs)

--- a/sciluigi/workflow.py
+++ b/sciluigi/workflow.py
@@ -125,7 +125,8 @@ class WorkflowTask(sciluigi.audit.AuditTrailHelpers, luigi.Task):
         Create new task instance, and link it to the current workflow.
         '''
         if 'sciluigi_reduce_function' not in kwargs:
-            kwargs['sciluigi_reduce_args'] = (self, instance_name, cls, kwargs)
+            kwargs['sciluigi_reduce_args'] = (self, instance_name, cls, kwargs, self._sciluigi_args,
+                                              self._sciluigi_kwargs)
             kwargs['sciluigi_reduce_function'] = sciluigi.task._new_task_unpickle
         newtask = sciluigi.new_task(instance_name, cls, self, **kwargs)
         self._tasks[instance_name] = newtask

--- a/sciluigi/workflow.py
+++ b/sciluigi/workflow.py
@@ -122,9 +122,15 @@ class WorkflowTask(sciluigi.audit.AuditTrailHelpers, luigi.Task):
         '''
         Create new task instance, and link it to the current workflow.
         '''
+        if 'sciluigi_reduce_function' not in kwargs:
+            kwargs['sciluigi_reduce_args'] = (instance_name, cls, kwargs)
+            kwargs['sciluigi_reduce_function']  = self._new_task_unpickle
         newtask = sciluigi.new_task(instance_name, cls, self, **kwargs)
         self._tasks[instance_name] = newtask
         return newtask
+
+    def _new_task_unpickle(self, instance_name, cls, kwargs):
+        return self.new_task(instance_name, cls, **kwargs)
 
 # ================================================================================
 

--- a/sciluigi/workflow.py
+++ b/sciluigi/workflow.py
@@ -32,8 +32,6 @@ class WorkflowTask(sciluigi.audit.AuditTrailHelpers, luigi.Task):
         self._wflogpath = ''
         self._hasloggedstart = False
         self._hasloggedfinish = False
-        self._sciluigi_args = args
-        self._sciluigi_kwargs = kwargs
 
     def _ensure_timestamp(self):
         '''
@@ -125,8 +123,7 @@ class WorkflowTask(sciluigi.audit.AuditTrailHelpers, luigi.Task):
         Create new task instance, and link it to the current workflow.
         '''
         if 'sciluigi_reduce_function' not in kwargs:
-            kwargs['sciluigi_reduce_args'] = (self, instance_name, cls, kwargs, self._sciluigi_args,
-                                              self._sciluigi_kwargs)
+            kwargs['sciluigi_reduce_args'] = (self, instance_name, cls, kwargs, self.__dict__)
             kwargs['sciluigi_reduce_function'] = sciluigi.task._new_task_unpickle
         newtask = sciluigi.new_task(instance_name, cls, self, **kwargs)
         self._tasks[instance_name] = newtask

--- a/sciluigi/workflow.py
+++ b/sciluigi/workflow.py
@@ -124,7 +124,7 @@ class WorkflowTask(sciluigi.audit.AuditTrailHelpers, luigi.Task):
         '''
         if 'sciluigi_reduce_function' not in kwargs:
             kwargs['sciluigi_reduce_args'] = (self, instance_name, cls, kwargs)
-            kwargs['sciluigi_reduce_function'] = sciluigi.Task._new_task_unpickle
+            kwargs['sciluigi_reduce_function'] = sciluigi.task._new_task_unpickle
         newtask = sciluigi.new_task(instance_name, cls, self, **kwargs)
         self._tasks[instance_name] = newtask
         return newtask

--- a/sciluigi/workflow.py
+++ b/sciluigi/workflow.py
@@ -12,6 +12,7 @@ import sciluigi.audit
 import sciluigi.interface
 import sciluigi.dependencies
 import sciluigi.slurm
+import traceback
 
 log = logging.getLogger('sciluigi-interface')
 
@@ -86,6 +87,7 @@ class WorkflowTask(sciluigi.audit.AuditTrailHelpers, luigi.Task):
             log.info('SciLuigi: %s Workflow Started', clsname)
             log.info('-'*80)
             self._hasloggedstart = True
+        traceback.print_stack()
         workflow_output = self.workflow()
         if workflow_output is None:
             clsname = self.__class__.__name__

--- a/sciluigi/workflow.py
+++ b/sciluigi/workflow.py
@@ -128,8 +128,8 @@ class WorkflowTask(sciluigi.audit.AuditTrailHelpers, luigi.Task):
         '''
         if 'sciluigi_reduce_function' not in kwargs:
             wf_dict = copy.deepcopy(self.__dict__)
-            if '_tasks' in wf_dict:
-                del wf_dict['_tasks']
+            # if '_tasks' in wf_dict:
+            #     del wf_dict['_tasks']
             kwargs['sciluigi_reduce_args'] = (self, instance_name, cls, copy.deepcopy(kwargs), wf_dict)
             kwargs['sciluigi_reduce_function'] = sciluigi.task._new_task_unpickle
         newtask = sciluigi.new_task(instance_name, cls, self, **kwargs)

--- a/sciluigi/workflow.py
+++ b/sciluigi/workflow.py
@@ -115,7 +115,7 @@ class WorkflowTask(sciluigi.audit.AuditTrailHelpers, luigi.Task):
         '''
         Create new task instance, and link it to the current workflow.
         '''
-        newtask = sciluigi.new_task(instance_name, cls, **kwargs)
+        newtask = sciluigi.new_task(instance_name, cls, self, **kwargs)
         self._tasks[instance_name] = newtask
         return newtask
 

--- a/sciluigi/workflow.py
+++ b/sciluigi/workflow.py
@@ -122,15 +122,15 @@ class WorkflowTask(sciluigi.audit.AuditTrailHelpers, luigi.Task):
         '''
         Create new task instance, and link it to the current workflow.
         '''
-        # if 'sciluigi_reduce_function' not in kwargs:
-        #     kwargs['sciluigi_reduce_args'] = (instance_name, cls, kwargs)
-        #     kwargs['sciluigi_reduce_function']  = self._new_task_unpickle
+        if 'sciluigi_reduce_function' not in kwargs:
+            kwargs['sciluigi_reduce_args'] = (instance_name, cls, kwargs)
+            kwargs['sciluigi_reduce_function'] = self._new_task_unpickle
         newtask = sciluigi.new_task(instance_name, cls, self, **kwargs)
         self._tasks[instance_name] = newtask
         return newtask
 
-    # def _new_task_unpickle(self, instance_name, cls, kwargs):
-    #     return self.new_task(instance_name, cls, **kwargs)
+    def _new_task_unpickle(self, instance_name, cls, kwargs):
+        return self.new_task(instance_name, cls, **kwargs)
 
 # ================================================================================
 

--- a/sciluigi/workflow.py
+++ b/sciluigi/workflow.py
@@ -26,12 +26,25 @@ class WorkflowTask(sciluigi.audit.AuditTrailHelpers, luigi.Task):
     instance_name = luigi.Parameter(default='sciluigi_workflow')
 
     def __init__(self, *args, **kwargs):
+        # When unpickling, kwargs will be smashed in with args
+        # Re-call __init__ with args in the proper format in this case
+        if len(args) and isinstance(args[-1], dict):
+            new_args = args[:-1]
+            new_kwargs = args[-1]
+            return self.__init__(*new_args, **new_kwargs)
+
         super(WorkflowTask, self).__init__(*args, **kwargs)
         self._tasks = {}
         self._wfstart = ''
         self._wflogpath = ''
         self._hasloggedstart = False
         self._hasloggedfinish = False
+        self._sciluigi_init_args = args
+        self._sciluigi_init_kwargs = kwargs
+
+    def __getinitargs__(self):
+        args_list = self._sciluigi_init_args + [self._sciluigi_init_kwargs]
+        return tuple(args_list)
 
     def _ensure_timestamp(self):
         '''

--- a/sciluigi/workflow.py
+++ b/sciluigi/workflow.py
@@ -122,15 +122,15 @@ class WorkflowTask(sciluigi.audit.AuditTrailHelpers, luigi.Task):
         '''
         Create new task instance, and link it to the current workflow.
         '''
-        if 'sciluigi_reduce_function' not in kwargs:
-            kwargs['sciluigi_reduce_args'] = (instance_name, cls, kwargs)
-            kwargs['sciluigi_reduce_function']  = self._new_task_unpickle
+        # if 'sciluigi_reduce_function' not in kwargs:
+        #     kwargs['sciluigi_reduce_args'] = (instance_name, cls, kwargs)
+        #     kwargs['sciluigi_reduce_function']  = self._new_task_unpickle
         newtask = sciluigi.new_task(instance_name, cls, self, **kwargs)
         self._tasks[instance_name] = newtask
         return newtask
 
-    def _new_task_unpickle(self, instance_name, cls, kwargs):
-        return self.new_task(instance_name, cls, **kwargs)
+    # def _new_task_unpickle(self, instance_name, cls, kwargs):
+    #     return self.new_task(instance_name, cls, **kwargs)
 
 # ================================================================================
 

--- a/sciluigi/workflow.py
+++ b/sciluigi/workflow.py
@@ -16,7 +16,7 @@ log = logging.getLogger('sciluigi-interface')
 
 # ==============================================================================
 
-class WorkflowTask(luigi.Task):
+class WorkflowTask(sciluigi.audit.AuditTrailHelpers, luigi.Task):
     '''
     SciLuigi-specific task, that has a method for implementing a (dynamic) workflow
     definition (workflow()).

--- a/sciluigi/workflow.py
+++ b/sciluigi/workflow.py
@@ -26,25 +26,12 @@ class WorkflowTask(sciluigi.audit.AuditTrailHelpers, luigi.Task):
     instance_name = luigi.Parameter(default='sciluigi_workflow')
 
     def __init__(self, *args, **kwargs):
-        # When unpickling, kwargs will be smashed in with args
-        # Re-call __init__ with args in the proper format in this case
-        if len(args) and isinstance(args[-1], dict):
-            new_args = args[:-1]
-            new_kwargs = args[-1]
-            return self.__init__(*new_args, **new_kwargs)
-
         super(WorkflowTask, self).__init__(*args, **kwargs)
         self._tasks = {}
         self._wfstart = ''
         self._wflogpath = ''
         self._hasloggedstart = False
         self._hasloggedfinish = False
-        self._sciluigi_init_args = args
-        self._sciluigi_init_kwargs = kwargs
-
-    def __getinitargs__(self):
-        args_list = self._sciluigi_init_args + [self._sciluigi_init_kwargs]
-        return tuple(args_list)
 
     def _ensure_timestamp(self):
         '''

--- a/sciluigi/workflow.py
+++ b/sciluigi/workflow.py
@@ -35,7 +35,7 @@ class WorkflowTask(sciluigi.audit.AuditTrailHelpers, luigi.Task):
 
     def __repr__(self):
         try:
-            super(WorkflowTask, self).__repr__()
+            return super(WorkflowTask, self).__repr__()
         except AttributeError:
             return self.__class__.__name__
 

--- a/sciluigi/workflow.py
+++ b/sciluigi/workflow.py
@@ -123,14 +123,11 @@ class WorkflowTask(sciluigi.audit.AuditTrailHelpers, luigi.Task):
         Create new task instance, and link it to the current workflow.
         '''
         if 'sciluigi_reduce_function' not in kwargs:
-            kwargs['sciluigi_reduce_args'] = (instance_name, cls, kwargs)
-            kwargs['sciluigi_reduce_function'] = self._new_task_unpickle
+            kwargs['sciluigi_reduce_args'] = (self, instance_name, cls, kwargs)
+            kwargs['sciluigi_reduce_function'] = sciluigi.Task._new_task_unpickle
         newtask = sciluigi.new_task(instance_name, cls, self, **kwargs)
         self._tasks[instance_name] = newtask
         return newtask
-
-    def _new_task_unpickle(self, instance_name, cls, kwargs):
-        return self.new_task(instance_name, cls, **kwargs)
 
 # ================================================================================
 

--- a/sciluigi/workflow.py
+++ b/sciluigi/workflow.py
@@ -115,7 +115,7 @@ class WorkflowTask(luigi.Task):
         '''
         Create new task instance, and link it to the current workflow.
         '''
-        newtask = sciluigi.new_task(instance_name, cls, self, **kwargs)
+        newtask = sciluigi.new_task(instance_name, cls, **kwargs)
         self._tasks[instance_name] = newtask
         return newtask
 

--- a/sciluigi/workflow.py
+++ b/sciluigi/workflow.py
@@ -123,7 +123,7 @@ class WorkflowTask(sciluigi.audit.AuditTrailHelpers, luigi.Task):
         Create new task instance, and link it to the current workflow.
         '''
         if 'sciluigi_reduce_function' not in kwargs:
-            kwargs['sciluigi_reduce_args'] = (self, instance_name, cls, kwargs, self.__dict__)
+            kwargs['sciluigi_reduce_args'] = (self, instance_name, cls, kwargs)
             kwargs['sciluigi_reduce_function'] = sciluigi.task._new_task_unpickle
         newtask = sciluigi.new_task(instance_name, cls, self, **kwargs)
         self._tasks[instance_name] = newtask


### PR DESCRIPTION
Required creating a custom `__reduce__` method for `sciluigi.Task` that reconstructs all tasks using the appropriate `new_task` method and then repopulates the original state of the object.  Without this custom method, sub-workflows and workflows did not properly re-populate their state upon unpickling.