### PR TITLE
Changing the Connection API

### DIFF
--- a/sciluigi/dependencies.py
+++ b/sciluigi/dependencies.py
@@ -214,6 +214,12 @@ class DependencyHelpers(object):
 
         if isinstance(val, TaskInput):
             tasks += val.tasks
+        elif isinstance(val, dict):
+            for item in val.values():
+                tasks = self._parse_inputitem(item, tasks)
+        elif isinstance(val, list):
+            for item in val:
+                tasks = self._parse_inputitem(item, tasks)
         else:
             raise Exception('Input item is neither callable nor a TaskInput: %s' % val)
         return tasks

--- a/sciluigi/dependencies.py
+++ b/sciluigi/dependencies.py
@@ -4,6 +4,7 @@ the dependency graph of workflows.
 '''
 
 import boto3
+from collections import Mapping, Sequence
 import luigi
 from luigi.s3 import S3Client, S3Target
 from luigi.six import iteritems
@@ -214,6 +215,12 @@ class DependencyHelpers(object):
 
         if isinstance(val, TaskInput):
             tasks += val.tasks
+        elif isinstance(val, Sequence):
+            for inputitem in val:
+                tasks += inputitem.tasks
+        elif isinstance(val, Mapping):
+            for inputitem in val.values():
+                tasks += inputitem.tasks
         else:
             raise Exception('Input item is neither callable nor a TaskInput: %s' % val)
         return tasks
@@ -275,10 +282,10 @@ class DependencyHelpers(object):
         elif isinstance (val, TaskInput):
             for info in val:
                 target_infos.append(info)
-        elif isinstance(val, list):
+        elif isinstance(val, Sequence):
             for valitem in val:
                 target_infos = self._parse_outputitem(valitem, target_infos)
-        elif isinstance(val, dict):
+        elif isinstance(val, Mapping):
             for _, valitem in iteritems(val):
                 target_infos = self._parse_outputitem(valitem, target_infos)
         else:

--- a/sciluigi/dependencies.py
+++ b/sciluigi/dependencies.py
@@ -214,12 +214,6 @@ class DependencyHelpers(object):
 
         if isinstance(val, TaskInput):
             tasks += val.tasks
-        elif isinstance(val, dict):
-            for item in val.values():
-                tasks = self._parse_inputitem(item, tasks)
-        elif isinstance(val, list):
-            for item in val:
-                tasks = self._parse_inputitem(item, tasks)
         else:
             raise Exception('Input item is neither callable nor a TaskInput: %s' % val)
         return tasks

--- a/sciluigi/task.py
+++ b/sciluigi/task.py
@@ -67,6 +67,26 @@ class Task(sciluigi.dependencies.DependencyHelpers, luigi.Task):
     def __reduce__(self):
         return self.sciluigi_reduce_function, self.sciluigi_reduce_args, self.sciluigi_state
 
+    def create_input(self, name):
+        if not name.startswith('in_'):
+            name = 'in_' + name
+        setattr(self, name, sciluigi.dependencies.TaskInput(self))
+
+    def create_output(self, name, value):
+        if not name.startswith('out_'):
+            name = 'out_' + name
+        setattr(self, name, value)
+
+    def get_input(self, name):
+        if not name.startswith('in_'):
+            name = 'in_' + name
+        return getattr(self, name)
+
+    def get_output(self, name):
+        if not name.startswith('out_'):
+            name = 'out_' + name
+        return getattr(self, name)
+
     def configure_instance(self):
         self.initialize_inputs_and_outputs()
 

--- a/sciluigi/task.py
+++ b/sciluigi/task.py
@@ -67,10 +67,10 @@ class Task(sciluigi.dependencies.DependencyHelpers, luigi.Task):
     def __reduce__(self):
         return self.sciluigi_reduce_function, self.sciluigi_reduce_args, self.sciluigi_state
 
-    def create_input(self, name):
+    def create_input(self, name, value):
         if not name.startswith('in_'):
             name = 'in_' + name
-        setattr(self, name, sciluigi.dependencies.TaskInput(self))
+        setattr(self, name, value)
 
     def create_output(self, name, value):
         if not name.startswith('out_'):

--- a/sciluigi/task.py
+++ b/sciluigi/task.py
@@ -67,26 +67,6 @@ class Task(sciluigi.dependencies.DependencyHelpers, luigi.Task):
     def __reduce__(self):
         return self.sciluigi_reduce_function, self.sciluigi_reduce_args, self.sciluigi_state
 
-    def create_input(self, name, value):
-        if not name.startswith('in_'):
-            name = 'in_' + name
-        setattr(self, name, value)
-
-    def create_output(self, name, value):
-        if not name.startswith('out_'):
-            name = 'out_' + name
-        setattr(self, name, value)
-
-    def get_input(self, name):
-        if not name.startswith('in_'):
-            name = 'in_' + name
-        return getattr(self, name)
-
-    def get_output(self, name):
-        if not name.startswith('out_'):
-            name = 'out_' + name
-        return getattr(self, name)
-
     def configure_instance(self):
         self.initialize_inputs_and_outputs()
 


### PR DESCRIPTION
Changing `connect()` methods to either `receive_from()` or `send_to()`.  Also adding more flexibility in input/output parsing to also handle objects that implement interface of `collections.Sequence` and `collections.Mapping` (i.e. `list` and `dict`, respectively)