### PR TITLE
Add ability to retrieve all outputs from a WorkflowTask

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ test/temp_test.py
 # Sphinx documentation
 doc/_build/
 doc/api/
+
+examples/sciluigi

--- a/sciluigi/workflow.py
+++ b/sciluigi/workflow.py
@@ -1,7 +1,8 @@
 import logging
+
 import luigi
-from luigi.six import iteritems
 import sciluigi
+from luigi.six import iteritems
 
 log = logging.getLogger('sciluigi-interface')
 
@@ -24,17 +25,16 @@ class WorkflowTask(sciluigi.task.Task):
         return [info.task for info in self.output_infos()]
 
     def mirror_outputs(self, inner_workflow, element_id=None):
-        # if isinstance(attrval, Mapping):
-        #     for key in attrval:
-        #         getattr(self, attrname)[key].receive_from(getattr(inner_workflow, attrname)[key])
-        # elif isinstance(attrval, Sequence):
-        #     for item in attrval:
-        #         get
-        # getattr(self, attrname).receive_from(getattr(inner_workflow, attrname))
-
-        for attrname, attrval in iteritems(inner_workflow.__dict__):
-            if 'out_' == attrname[0:4]:
+        for attr_name, attr_val in iteritems(inner_workflow.__dict__):
+            if attr_name.startswith('out_'):
                 if element_id is not None:
-                    setattr(self, '%s-%s-%s' % (attrname, element_id, inner_workflow.instance_name), attrval)
+                    setattr(self, '%s-%s-%s' % (attr_name, element_id, inner_workflow.instance_name), attr_val)
                 else:
-                    setattr(self, '%s-%s' % (attrname, inner_workflow.instance_name), attrval)
+                    setattr(self, '%s-%s' % (attr_name, inner_workflow.instance_name), attr_val)
+
+    def get_all_outputs(self):
+        """
+        Retrieve a list of all task outputs (i.e. those that start with 'out_')
+        :return: a list of all task outputs
+        """
+        return [attr_val for attr_name, attr_val in iteritems(self.__dict__) if attr_name.startswith('out_')]

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,3 @@
-import os
-import sys
-
 try:
     from setuptools import setup
 except:
@@ -18,7 +15,7 @@ with open('README.rst') as fobj:
 
 setup(
     name='h3sciluigi',
-    version='5.1.0',
+    version='5.2.0',
     description='Helper library for writing dynamic, flexible workflows in luigi',
     long_description=long_description,
     author='Samuel Lampa and Michael Soltow',
@@ -32,7 +29,7 @@ setup(
     install_requires=[
         'h3luigi',
         'sphinx_rtd_theme'
-        ],
+    ],
     entry_points={
         'console_scripts': [
             'sciluigi = sciluigi.cmdline:sciluigi_run'


### PR DESCRIPTION
Added `get_all_outputs` which is analogous to `mirror_outputs`, but to be used to connect all outputs of a task to the input of another